### PR TITLE
shift BASE offset to miss Arduino OTA 128 bytes

### DIFF
--- a/RTCVars.cpp
+++ b/RTCVars.cpp
@@ -1,9 +1,9 @@
 #include "Arduino.h"
 #include "RTCVars.h"
 
-#define RTC_BASE 28                   // this is a known good offset for unused RTC memory
+#define RTC_BASE 33                   // this is a known good offset for unused RTC memory
 #define RTC_STATE_HEADER_SIZE   6     // 3 bytes signature, 1 byte state_id, 2 byte  
-#define RTC_MAX_SIZE (511 - RTC_BASE) // 512 - RTC_BASE - 1 for checksum
+#define RTC_MAX_SIZE (511 - (RTC_BASE*4)) // 512 - (RTC_BASE*4) - 1 for checksum
 
 #define RTC_STATE_TYPE_NONE     0
 #define RTC_STATE_TYPE_INT      1


### PR DESCRIPTION
Shifted the offset to avoid the 128 bytes (32 4-byte slots). I put the offset at 33 and also made a correction to the calculation of RTC_MAX_SIZE since it treated RTC_BASE as a number of bytes rather than the number of 4-byte slots that it appears to be.